### PR TITLE
Start service after NGINX

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Control server for the WireGuard-based VPN
 After=network.target
+After=nginx.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
I sometimes encounter a race condition where Headscale starts before NGINX, but Headscale tries to contact the OIDC provider upon starting, thus fails.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
