### PR TITLE
Avoid using gawk

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -90,4 +90,4 @@ ram.runtime = "50M"
     stun.exposed = "UDP"
 
     [resources.apt]
-    packages = "ethtool, gawk"
+    packages = "ethtool"

--- a/scripts/install
+++ b/scripts/install
@@ -17,8 +17,12 @@ if yunohost app list | grep -q "$YNH_APP_ARG_DEX_DOMAIN$YNH_APP_ARG_DEX_PATH"; t
 fi
 
 yunohost app install https://github.com/YunoHost-Apps/dex_ynh --force --args "domain=$dex_domain&path=$dex_path&oidc_name=$oidc_name&oidc_secret=$oidc_secret&oidc_callback=$oidc_callback" 2>&1 | tee dexlog.txt
-dex_app=$(gawk 'match($0, /Installation of (.+) completed/, app) {print app[1]}' dexlog.txt)
+dex_app=$(grep -Po 'Installation of\s+\K.*(?=\s+completed)' dexlog.txt)
 rm dexlog.txt
+
+if [ -z "$dex_app" ]; then
+  ynh_die "Dex package installation failed"
+fi
 
 # Create Dex URIs
 if [ $dex_path = "/" ]


### PR DESCRIPTION
## Solution

Same as https://github.com/YunoHost-Apps/outline_ynh/pull/128

grep is present by default on every system. This commit suggests to remove the gawk dependency 
Also this checks the dex app id could have been retrieved.

This commit is a suggestion, I don't have strong opinion about it, so feel free to reject it.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
