### PR TITLE
Possible improvement for linter

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -22,7 +22,7 @@ setup_dex() {
 
 	# Make sure that the Dex version is compatible
 	dex_version=$(yunohost app info $dex --output-as json | jq -r '.version')
-	if [ $(dpkg --compare-versions "${dex_version#v}" lt "2.42.1~ynh4") ]; then
+	if dpkg --compare-versions "${dex_version#v}" lt "2.42.1~ynh4"; then
 		ynh_die "You need to upgrade $dex to v2.42.1~ynh4 and above first."
 	fi
 


### PR DESCRIPTION
## Problem

The linter reports this issue since [this improvement](https://github.com/YunoHost/package_linter/commit/d6803e1397c4c292fdddb8f8f86a032308121aa0):
```
 ! scripts/_common.sh

    ! Syntaxes like « if [ $(cmd) ] » is pretty much a nonsense in bash and probably doesnt mean what you think it means ... If you want to check that the output of the command is non-empty, use « [ -n "$(cmd)" ] ». If you want to check for the return-code of the command, simply use « if cmd » (possibly with >/dev/null 2>/dev/null).
Culprit(s):

[ $(dpkg --compare-versions "${dex_version#v}" lt "2.42.1~ynh4") ]; then 
```

## Solution

- Remove the brackets

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
